### PR TITLE
fix(jenkins): need a newer version of cf api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,1 @@
-certifi==2017.11.5
-chardet==3.0.4
-cloudflare==1.8.1
-future==0.16.0
-idna==2.6
-PyYAML==3.12
-requests==2.18.4
-urllib3==1.22
+cloudflare


### PR DESCRIPTION
This is just to fix the jenkins build. The cloudflare API servers will return "Invalid Headers" if you have both the token and email. It will also return "Invalid Headers" if your version of the python api is too old to know about the former. It also returns "Invalid Headers" if you screw up the token somehow...

Going to push a specific (jbarno_update) tag for this to docker hub and get jenkins working again. 